### PR TITLE
Add correct org for appdirs on Win

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 
 [build-status-travis]: https://travis-ci.org/golemfactory/golem-client.svg?branch=master
 [travis]: https://travis-ci.org/golemfactory/golem-client
-[build-status-appveyor]: https://ci.appveyor.com/api/projects/status/github/golemfactory/golem-client?svg=true
-[appveyor]: https://ci.appveyor.com/project/golemfactory/golem-client
+[build-status-appveyor]: https://ci.appveyor.com/api/projects/status/github/prekucki/golem-client?svg=true
+[appveyor]: https://ci.appveyor.com/project/prekucki/golem-client
 
 [Project roadmap](https://docs.google.com/document/d/1h1pUB-LT6YwozfqX9rAO7vrgzM5CaGGr9WsePeZ95C8) 
 

--- a/golemcli/src/main.rs
+++ b/golemcli/src/main.rs
@@ -57,16 +57,10 @@ impl CliArgs {
     pub fn get_data_dir(&self) -> PathBuf {
         match &self.data_dir {
             Some(data_dir) => data_dir.join("rinkeby"),
-            None => {
-                let data_dir = appdirs::user_data_dir(Some("golem"), None, false).unwrap();
-                if cfg!(windows) {
-                    data_dir.join("golem")
-                } else {
-                    data_dir
-                }
+            None => appdirs::user_data_dir(Some("golem"), Some("golem"), false)
+                .unwrap()
                 .join("default")
-                .join("rinkeby")
-            }
+                .join("rinkeby"),
         }
     }
 


### PR DESCRIPTION
On Win, Golem's datadir resides in:

```
AppData\Local\golem\golem\default\{rinkeby,mainnet}
```

This PR fixes `get_data_dir` to correctly point to that dir. It also updates links to appveyor build and badge.