### PR TITLE
Include OSX in travis and check formatting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,21 @@
 language: rust
+os:
+    - linux
+    - osx
 rust:
-- stable
-- beta
+    - stable
+    - beta
+matrix:
+    allow_failures: beta
+    fast_finish: true
+before_script:
+    - rustup toolchain install stable
+    - rustup component add rustfmt --toolchain stable
+    - rustup component list --toolchain stable
+    - rustup show
 script:
-- cargo build --verbose
-- cargo test --verbose
+    - cargo +stable fmt --all -- --check
+    - cargo build --release
+    - cargo build
+    - RUST_BACKTRACE=1 cargo test
 


### PR DESCRIPTION
Since we already have automated builds for Linux and Windows, I've decided to add it also for Mac. Additionally, it works pretty well to have CI check for formatting issues, so I've added to our `.travis.yml`.