### PR TITLE
Add `ErrorCreating` variant to `TaskStatus`

### DIFF
--- a/golem-rpc-api/src/comp.rs
+++ b/golem-rpc-api/src/comp.rs
@@ -153,6 +153,8 @@ pub struct TaskTestResult {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum TaskStatus {
+    #[serde(rename = "Error creating")]
+    ErrorCreating,
     #[serde(rename = "Not started")]
     NotStarted,
     #[serde(rename = "Creating the deposit")]


### PR DESCRIPTION
This PR updates `TaskStatus` enum with ~~two~~ a new variant~~s~~ that was ~~were~~ added in golemfactory/golem#4324:
* ~~Creating ([link](https://github.com/golemfactory/golem/pull/4324/files#diff-fb1ffc3869aa39f4d7fe83961834b77eR155))~~ duplicated effort, waiting on merge in #56 
* ErrorCreating ([link](https://github.com/golemfactory/golem/pull/4324/files#diff-fb1ffc3869aa39f4d7fe83961834b77eR156))