### PR TITLE
For crates from the same workspace, use path deps

### DIFF
--- a/golem-rpc-api/Cargo.toml
+++ b/golem-rpc-api/Cargo.toml
@@ -18,8 +18,8 @@ default = ["settings"]
 settings = ["golem-rpc-macros"]
 
 [dependencies]
-actix-wamp = "0.2.0"
-golem-rpc-macros = { version = "0.2.0", optional = true }
+actix-wamp = { path = "../actix-wamp", version = "0.2.0" }
+golem-rpc-macros = { path = "../golem-rpc-macros", version = "0.2.0", optional = true }
 
 bigdecimal = { version = "0.1.0", features = ["serde"] }
 chrono = { version = "0.4.6", features = ["serde"] }

--- a/golemcli/Cargo.toml
+++ b/golemcli/Cargo.toml
@@ -14,8 +14,8 @@ interactive_cli = ["rustyline", "atty", "ansi_term"]
 test_task_cli = []
 
 [dependencies]
-actix-wamp = "0.2.0"
-golem-rpc-api = { version = "0.2.0", features = ['settings'] }
+actix-wamp = { path = "../actix-wamp", version = "0.2.0" }
+golem-rpc-api = { path = "../golem-rpc-api", version = "0.2.0", features = ['settings'] }
 
 actix = "0.9"
 actix-rt="1.0.0"


### PR DESCRIPTION
This commit makes all dependencies that coem from the same workspace
`path` dependencies using the syntax:

```toml
actix-wamp = { path = "../actix-wamp", version = "0.2.0" }
```

Note that versioning info for local crates stays the same, however
the addition of `path` info makes the workspace and crates within
reusable if someone wants to link to the them via `git` or `path`
dependency. Also, if it ever so happens that one of the local crates
is not published but linked with the specified version number, the
project will no longer build stating it cannot resolve the dependency.
With this fix, this will no longer be a problem which is exactly
the problem right now.